### PR TITLE
Refactor code to support nested-kind handling, e.g. Bifunctor as Functor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	swift build -c release
+
+test:
+	swift test -c release

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ let list = [1, 2, 3].kind
 list == List.cons(1, .cons(2, .cons(3, .nil)))
 ```
 
+## Warning
+
+There is a Swift 4.2 compiler bug (?) when `swift build -c debug`, so please always build with `swift build -c release`.
+
 ## References
 
 - [Lightweight Higher-Kinded Polymorphism][flops-2014-paper]

--- a/Sources/HigherKindSwift/Core/ForTypeConstructor.swift
+++ b/Sources/HigherKindSwift/Core/ForTypeConstructor.swift
@@ -1,2 +1,0 @@
-public protocol ForTypeConstructor {}
-public protocol ForTypeConstructor2 {}

--- a/Sources/HigherKindSwift/Core/Kind.swift
+++ b/Sources/HigherKindSwift/Core/Kind.swift
@@ -1,7 +1,7 @@
 // MARK: - Kind
 
 /// `F` as `* -> *`.
-public struct Kind<F: ForTypeConstructor, A1>
+public struct Kind<F1, A1>
 {
     internal let _value: Any
 
@@ -13,12 +13,12 @@ public struct Kind<F: ForTypeConstructor, A1>
 
 extension Kind: KindConvertible
 {
-    public init(kind: Kind<F, A1>)
+    public init(kind: Kind<F1, A1>)
     {
         self = kind
     }
 
-    public var kind: Kind<F, A1>
+    public var kind: Kind<F1, A1>
     {
         return self
     }
@@ -27,7 +27,7 @@ extension Kind: KindConvertible
 // MARK: - Kind2
 
 /// `F` as `* -> * -> *`.
-public struct Kind2<F: ForTypeConstructor2, A1, A2>
+public struct Kind2<F2, A2, A1>
 {
     internal let _value: Any
 
@@ -39,12 +39,12 @@ public struct Kind2<F: ForTypeConstructor2, A1, A2>
 
 extension Kind2: Kind2Convertible
 {
-    public init(kind2: Kind2<F, A1, A2>)
+    public init(kind2: Kind2<F2, A2, A1>)
     {
         self = kind2
     }
 
-    public var kind2: Kind2<F, A1, A2>
+    public var kind2: Kind2<F2, A2, A1>
     {
         return self
     }

--- a/Sources/HigherKindSwift/Core/KindConvertible.swift
+++ b/Sources/HigherKindSwift/Core/KindConvertible.swift
@@ -1,20 +1,36 @@
 public protocol KindConvertible
 {
-    associatedtype F: ForTypeConstructor
+    associatedtype F1
     associatedtype A1
 
-    init(kind: Kind<F, A1>)
+    init(kind: Kind<F1, A1>)
 
-    var kind: Kind<F, A1> { get }
+    var kind: Kind<F1, A1> { get }
 }
 
-public protocol Kind2Convertible
+public protocol Kind2Convertible: KindConvertible where F1 == Kind<F2, A2>
 {
-    associatedtype F: ForTypeConstructor2
-    associatedtype A1
+    associatedtype F2
     associatedtype A2
 
-    init(kind2: Kind2<F, A1, A2>)
+    init(kind2: Kind2<F2, A2, A1>)
 
-    var kind2: Kind2<F, A1, A2> { get }
+    var kind2: Kind2<F2, A2, A1> { get }
+}
+
+// MARK: - Default implementation
+
+extension Kind2Convertible
+{
+    // Default implementation.
+    public init(kind: Kind<F1, A1>)
+    {
+        self.init(kind2: Kind2.init(kind._value))
+    }
+
+    // Default implementation.
+    public var kind: Kind<F1, A1>
+    {
+        return Kind(self.kind2._value)
+    }
 }

--- a/Sources/HigherKindSwift/Typeclasses/Applicative.swift
+++ b/Sources/HigherKindSwift/Typeclasses/Applicative.swift
@@ -1,9 +1,9 @@
 // MARK: - Applicative
 
-public protocol Applicative: Functor where F: ForApplicative
+public protocol Applicative: Functor where F1: ForApplicative
 {
-    static func pure<A>(_ value: A) -> Kind<F, A>
-    static func apply<A, B>(_ f: Kind<F, (A) -> B>, _ a: Kind<F, A>) -> Kind<F, B>
+    static func pure(_ value: A1) -> Kind<F1, A1>
+    static func apply<B>(_ f: Kind<F1, (A1) -> B>, _ a: Kind<F1, A1>) -> Kind<F1, B>
 }
 
 // MARK: - ForApplicative
@@ -14,20 +14,22 @@ public protocol ForApplicative: ForFunctor
     static func apply<A, B>(_ f: Kind<Self, (A) -> B>, _ a: Kind<Self, A>) -> Kind<Self, B>
 }
 
-extension Kind: Applicative where F: ForApplicative
+// MARK: - Default implementation
+
+extension Kind: Applicative where F1: ForApplicative
 {
-    public static func pure<A>(_ value: A) -> Kind<F, A>
+    // Default implementation.
+    public static func pure(_ value: A1) -> Kind<F1, A1>
     {
-        return F.pure(value)
+        return F1.pure(value)
     }
 
-    public static func apply<A, B>(_ f: Kind<F, (A) -> B>, _ a: Kind<F, A>) -> Kind<F, B>
+    // Default implementation.
+    public static func apply<B>(_ f: Kind<F1, (A1) -> B>, _ a: Kind<F1, A1>) -> Kind<F1, B>
     {
-        return F.apply(f, a)
+        return F1.apply(f, a)
     }
 }
-
-// MARK: - PseudoApplicative
 
 /// - Note:
 /// Use this fancy protocol for true type-constructors.

--- a/Sources/HigherKindSwift/Typeclasses/Bifunctor.swift
+++ b/Sources/HigherKindSwift/Typeclasses/Bifunctor.swift
@@ -2,55 +2,94 @@
 
 public protocol Bifunctor
 {
-    associatedtype F: ForBifunctor
-    associatedtype A1
+    associatedtype F2: ForBifunctor
     associatedtype A2
+    associatedtype A1
 
-    func first<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F, B1, A2>
-    func second<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F, A1, B2>
+    func bimap<B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> Kind2<F2, B2, B1>
+
+    func first<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F2, B2, A1>
+    func second<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F2, A2, B1>
 }
 
 // MARK: - ForBifunctor
 
 /// - Minimal: bimap | first, second
-public protocol ForBifunctor: ForTypeConstructor2
+public protocol ForBifunctor: ForFunctor2
 {
-    static func bimap<A1, A2, B1, B2>(_ f1: @escaping (A1) -> B1, _ f2: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, B2>
-    static func first<A1, A2, B1>(_ f: @escaping (A1) -> B1) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, A2>
-    static func second<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, A1, B2>
+    static func bimap<A2, A1, B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, B1>
+
+    static func first<A2, A1, B2>(
+        _ f: @escaping (A2) -> B2
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, A1>
+
+    static func second<A2, A1, B1>(
+        _ f: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, A2, B1>
 }
 
 extension ForBifunctor
 {
     /// Default implementation.
-    public static func bimap<A1, A2, B1, B2>(_ f1: @escaping (A1) -> B1, _ f2: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, B2>
+    public static func bimap<A2, A1, B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, B1>
     {
-        return { $0.first(f1).second(f2) }
+        return { self.second(f2)(self.first(f1)($0)) }
     }
 
     /// Default implementation.
-    public static func first<A1, A2, B1>(_ f: @escaping (A1) -> B1) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, A2>
+    public static func first<A2, A1, B2>(
+        _ f: @escaping (A2) -> B2
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, A1>
     {
         return self.bimap(f, { $0 })
     }
 
     /// Default implementation.
-    public static func second<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, A1, B2>
+    public static func second<A2, A1, B1>(
+        _ f: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, A2, B1>
     {
         return self.bimap({ $0 }, f)
     }
+
+    /// Default implementation.
+    public static func fmap<A2, A, B>(
+        _ f: @escaping (A) -> B
+        ) -> (Kind<Kind<Self, A2>, A>) -> Kind<Kind<Self, A2>, B>
+    {
+        return { Kind2<Self, A2, A>($0._value).second(f).kind }
+    }
 }
 
-extension Kind2: Bifunctor where F: ForBifunctor
+// MARK: - Default implementation
+
+extension Kind2: Bifunctor where F2: ForBifunctor
 {
-    public func first<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F, B1, A2>
+    public func bimap<B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> Kind2<F2, B2, B1>
     {
-        return F.first(f)(self)
+        return F2.bimap(f1, f2)(self)
     }
 
-    public func second<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F, A1, B2>
+    public func first<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F2, B2, A1>
     {
-        return F.second(f)(self)
+        return F2.first(f)(self)
+    }
+
+    public func second<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F2, A2, B1>
+    {
+        return F2.second(f)(self)
     }
 }
 

--- a/Sources/HigherKindSwift/Typeclasses/ForFunctor2.swift
+++ b/Sources/HigherKindSwift/Typeclasses/ForFunctor2.swift
@@ -1,0 +1,78 @@
+// IMPORTANT:
+// This file defines `ForFunctor2`, `ForApplicative2`, `ForMonad2` to allow
+// nested kinds e.g. `Kind<Kind<ForReader, A2>, A1>` work as Functor and so on.
+// But due to Swift 4.2 limitation, **they must be bundled in one file,
+// or compiler (with debug configuration) fails type checking for some reason**.
+//
+// NOTE:
+// This problem can be avoided by `swift build -c release`.
+
+// MARK: - ForFunctor2
+
+/// `Functor` support for nested `Kind`s.
+/// - Todo: Can we unify this with `ForFunctor`?
+public protocol ForFunctor2
+{
+    static func fmap<A2, A, B>(_ f: @escaping (A) -> B) -> (Kind<Kind<Self, A2>, A>) -> Kind<Kind<Self, A2>, B>
+}
+
+extension Kind: ForFunctor where F1: ForFunctor2
+{
+    public static func fmap<A, B>(
+        _ f: @escaping (A) -> B
+        ) -> (Kind<Kind<F1, A1>, A>) -> Kind<Kind<F1, A1>, B>
+    {
+        return F1.fmap(f)
+    }
+}
+
+// MARK: - ForApplicative2
+
+/// `Applicative` support for nested `Kind`s.
+/// - Todo: Can we unify this with `ForApplicative`?
+public protocol ForApplicative2: ForFunctor2
+{
+    static func pure<A2, A>(_ value: A) -> Kind<Kind<Self, A2>, A>
+
+    static func apply<A2, A, B>(
+        _ f: Kind<Kind<Self, A2>, (A) -> B>,
+        _ a: Kind<Kind<Self, A2>, A>
+        ) -> Kind<Kind<Self, A2>, B>
+}
+
+extension Kind: ForApplicative where F1: ForApplicative2
+{
+    public static func pure<A>(_ value: A) -> Kind<Kind<F1, A1>, A>
+    {
+        return F1.pure(value)
+    }
+
+    public static func apply<A, B>(
+        _ f: Kind<Kind<F1, A1>, (A) -> B>,
+        _ a: Kind<Kind<F1, A1>, A>
+        ) -> Kind<Kind<F1, A1>, B>
+    {
+        return F1.apply(f, a)
+    }
+}
+
+// MARK: - ForMonad2
+
+/// `Monad` support for nested `Kind`s.
+/// - Todo: Can we unify this with `ForMonad`?
+public protocol ForMonad2: ForApplicative2
+{
+    static func bind<A2, A, B>(
+        _ f: @escaping (A) -> Kind<Kind<Self, A2>, B>
+        ) -> (Kind<Kind<Self, A2>, A>) -> Kind<Kind<Self, A2>, B>
+}
+
+extension Kind: ForMonad where F1: ForMonad2
+{
+    public static func bind<A, B>(
+        _ f: @escaping (A) -> Kind<Kind<F1, A1>, B>
+        ) -> (Kind<Kind<F1, A1>, A>) -> Kind<Kind<F1, A1>, B>
+    {
+        return F1.bind(f)
+    }
+}

--- a/Sources/HigherKindSwift/Typeclasses/Functor.swift
+++ b/Sources/HigherKindSwift/Typeclasses/Functor.swift
@@ -2,24 +2,27 @@
 
 public protocol Functor
 {
-    associatedtype F: ForFunctor
+    associatedtype F1: ForFunctor
     associatedtype A1
 
-    func fmap<B>(_ f: @escaping (A1) -> B) -> Kind<F, B>
+    func fmap<B>(_ f: @escaping (A1) -> B) -> Kind<F1, B>
 }
 
 // MARK: - ForFunctor
 
-public protocol ForFunctor: ForTypeConstructor
+public protocol ForFunctor
 {
     static func fmap<A, B>(_ f: @escaping (A) -> B) -> (Kind<Self, A>) -> Kind<Self, B>
 }
 
-extension Kind: Functor where F: ForFunctor
+// MARK: - Default implementation
+
+extension Kind: Functor where F1: ForFunctor
 {
-    public func fmap<B>(_ f: @escaping (A1) -> B) -> Kind<F, B>
+    // Default implementation.
+    public func fmap<B>(_ f: @escaping (A1) -> B) -> Kind<F1, B>
     {
-        return F.fmap(f)(self)
+        return F1.fmap(f)(self)
     }
 }
 

--- a/Sources/HigherKindSwift/Typeclasses/Monad.swift
+++ b/Sources/HigherKindSwift/Typeclasses/Monad.swift
@@ -1,8 +1,8 @@
 // MARK: - Monad
 
-public protocol Monad: Applicative where F: ForMonad
+public protocol Monad: Applicative where F1: ForMonad
 {
-    func bind<B>(_ f: @escaping (A1) -> Kind<F, B>) -> Kind<F, B>
+    func bind<B>(_ f: @escaping (A1) -> Kind<F1, B>) -> Kind<F1, B>
 }
 
 // MARK: - ForMonad
@@ -12,16 +12,14 @@ public protocol ForMonad: ForApplicative
     static func bind<A, B>(_ f: @escaping (A) -> Kind<Self, B>) -> (Kind<Self, A>) -> Kind<Self, B>
 }
 
-extension Kind: Monad where F: ForMonad
-{
-    public static func pure<A>(_ value: A) -> Kind<F, A>
-    {
-        return F.pure(value)
-    }
+// MARK: - Default implementation
 
-    public func bind<B>(_ f: @escaping (A1) -> Kind<F, B>) -> Kind<F, B>
+extension Kind: Monad where F1: ForMonad
+{
+    // Default implementation.
+    public func bind<B>(_ f: @escaping (A1) -> Kind<F1, B>) -> Kind<F1, B>
     {
-        return F.bind(f)(self)
+        return F1.bind(f)(self)
     }
 }
 

--- a/Sources/HigherKindSwift/Typeclasses/MonadPlus.swift
+++ b/Sources/HigherKindSwift/Typeclasses/MonadPlus.swift
@@ -1,9 +1,9 @@
 // MARK: - MonadPlus
 
-public protocol MonadPlus: Monad where F: ForMonadPlus
+public protocol MonadPlus: Monad where F1: ForMonadPlus
 {
-    static func mzero<A>() -> Kind<F, A>
-    func mplus(_ kind: Kind<F, A1>) -> Kind<F, A1>
+    static func mzero<A>() -> Kind<F1, A>
+    func mplus(_ kind: Kind<F1, A1>) -> Kind<F1, A1>
 }
 
 // MARK: - ForMonadPlus
@@ -14,16 +14,18 @@ public protocol ForMonadPlus: ForMonad
     static func mplus<A>(_ kind1: Kind<Self, A>, _ kind2: Kind<Self, A>) -> Kind<Self, A>
 }
 
-extension Kind: MonadPlus where F: ForMonadPlus
+// MARK: - Default implementation
+
+extension Kind: MonadPlus where F1: ForMonadPlus
 {
-    public static func mzero<A>() -> Kind<F, A>
+    public static func mzero<A>() -> Kind<F1, A>
     {
-        return F.mzero()
+        return F1.mzero()
     }
 
-    public func mplus(_ kind: Kind<F, A1>) -> Kind<F, A1>
+    public func mplus(_ kind: Kind<F1, A1>) -> Kind<F1, A1>
     {
-        return F.mplus(self, kind)
+        return F1.mplus(self, kind)
     }
 }
 

--- a/Sources/HigherKindSwift/Typeclasses/NaturalTransformation.swift
+++ b/Sources/HigherKindSwift/Typeclasses/NaturalTransformation.swift
@@ -8,15 +8,19 @@ public protocol NaturalTransformation
     static func naturalTransform<A>(_ kind: Kind<F, A>) -> Kind<G, A>
 }
 
-extension Kind where F: ForFunctor
+// MARK: - Default implementation
+
+extension Kind where F1: ForFunctor
 {
+    // Default implementation.
     public func naturalTransform<NT: NaturalTransformation>(_ transformation: NT.Type) -> Kind<NT.G, A1>
-        where NT.F == F
+        where NT.F == F1
     {
         return NT.naturalTransform(self)
     }
 
-    public func naturalTransform<G: ForFunctor>(_ transform: (Kind<F, A1>) -> Kind<G, A1>) -> Kind<G, A1>
+    // Default implementation.
+    public func naturalTransform<G: ForFunctor>(_ transform: (Kind<F1, A1>) -> Kind<G, A1>) -> Kind<G, A1>
     {
         return transform(self)
     }

--- a/Sources/HigherKindSwift/Typeclasses/Profunctor.swift
+++ b/Sources/HigherKindSwift/Typeclasses/Profunctor.swift
@@ -2,61 +2,80 @@
 
 public protocol Profunctor
 {
-    associatedtype F: ForProfunctor
-    associatedtype A1
+    associatedtype F2: ForProfunctor
     associatedtype A2
+    associatedtype A1
 
-    func dimap<B1, B2>(_ f1: @escaping (B1) -> A1, _ f2: @escaping (A2) -> B2) -> Kind2<F, B1, B2>
-    func lmap<B1>(_ f: @escaping (B1) -> A1) -> Kind2<F, B1, A2>
-    func rmap<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F, A1, B2>
+    func dimap<B2, B1>(_ f1: @escaping (B2) -> A2, _ f2: @escaping (A1) -> B1) -> Kind2<F2, B2, B1>
+    func lmap<B2>(_ f: @escaping (B2) -> A2) -> Kind2<F2, B2, A1>
+    func rmap<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F2, A2, B1>
 }
 
 // MARK: - ForProfunctor
 
 /// - Minimal: dimap | lmap, rmap
-public protocol ForProfunctor: ForTypeConstructor2
+public protocol ForProfunctor
 {
-    static func dimap<A1, A2, B1, B2>(_ f1: @escaping (B1) -> A1, _ f2: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, B2>
-    static func lmap<A1, A2, B1>(_ f: @escaping (B1) -> A1) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, A2>
-    static func rmap<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, A1, B2>
+    static func dimap<A2, A1, B2, B1>(
+        _ f1: @escaping (B2) -> A2,
+        _ f2: @escaping (A1) -> B1)
+        -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, B1>
+
+    static func lmap<A2, A1, B2>(_ f: @escaping (B2) -> A2)
+        -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, A1>
+
+    static func rmap<A2, A1, B1>(_ f: @escaping (A1) -> B1)
+        -> (Kind2<Self, A2, A1>) -> Kind2<Self, A2, B1>
 }
 
 extension ForProfunctor
 {
     /// Default implementation.
-    public static func dimap<A1, A2, B1, B2>(_ f1: @escaping (B1) -> A1, _ f2: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, B2>
+    public static func dimap<A2, A1, B2, B1>(
+        _ f1: @escaping (B2) -> A2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, B1>
     {
-        return { $0.rmap(f2).lmap(f1) }
+        return { self.lmap(f1)(self.rmap(f2)($0)) }
     }
 
     /// Default implementation.
-    public static func lmap<A1, A2, B1>(_ f: @escaping (B1) -> A1) -> (Kind2<Self, A1, A2>) -> Kind2<Self, B1, A2>
+    public static func lmap<A2, A1, B2>(
+        _ f: @escaping (B2) -> A2
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, B2, A1>
     {
         return self.dimap(f, { $0 })
     }
 
     /// Default implementation.
-    public static func rmap<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<Self, A1, A2>) -> Kind2<Self, A1, B2>
+    public static func rmap<A2, A1, B1>(
+        _ f: @escaping (A1) -> B1
+        ) -> (Kind2<Self, A2, A1>) -> Kind2<Self, A2, B1>
     {
         return self.dimap({ $0 }, f)
     }
 }
 
-extension Kind2: Profunctor where F: ForProfunctor
+// MARK: - Default implementation
+
+extension Kind2: Profunctor where F2: ForProfunctor
 {
-    public func dimap<B1, B2>(_ f1: @escaping (B1) -> A1, _ f2: @escaping (A2) -> B2) -> Kind2<F, B1, B2>
+    public func dimap<B2, B1>(
+        _ f1: @escaping (B2) -> A2,
+        _ f2: @escaping (A1) -> B1
+        ) -> Kind2<F2, B2, B1>
     {
-        return F.dimap(f1, f2)(self)
+        return F2.dimap(f1, f2)(self)
     }
 
-    public func lmap<B1>(_ f: @escaping (B1) -> A1) -> Kind2<F, B1, A2>
+    public func lmap<B2>(_ f: @escaping (B2) -> A2) -> Kind2<F2, B2, A1>
     {
-        return F.lmap(f)(self)
+        return F2.lmap(f)(self)
     }
 
-    public func rmap<B2>(_ f: @escaping (A2) -> B2) -> Kind2<F, A1, B2>
+    public func rmap<B1>(_ f: @escaping (A1) -> B1) -> Kind2<F2, A2, B1>
     {
-        return F.rmap(f)(self)
+        return F2.rmap(f)(self)
     }
 }
 

--- a/Sources/HigherKindSwift/Types/Array.swift
+++ b/Sources/HigherKindSwift/Types/Array.swift
@@ -30,12 +30,12 @@ extension Array: PseudoFunctor
 /// - Note: autogeneratable
 extension Array: PseudoApplicative
 {
-    public static func pure<A>(_ value: A) -> Array<A>
+    public static func pure(_ value: A1) -> Array<A1>
     {
         return ForArray.pure(value).value
     }
 
-    public static func apply<A, B>(_ f: Array<(A) -> B>, _ a: Array<A>) -> Array<B>
+    public static func apply<B>(_ f: Array<(A1) -> B>, _ a: Array<A1>) -> Array<B>
     {
         return ForArray.apply(f.kind, a.kind).value
     }
@@ -56,7 +56,7 @@ extension Array: PseudoMonad
 public enum ForArray {}
 
 /// - Note: autogeneratable
-extension Kind where F == ForArray
+extension Kind where F1 == ForArray
 {
     public var value: Array<A1>
     {
@@ -79,7 +79,10 @@ extension ForArray: ForApplicative
         return [value].kind
     }
 
-    public static func apply<A, B>(_ f: Kind<ForArray, (A) -> B>, _ a: Kind<ForArray, A>) -> Kind<ForArray, B>
+    public static func apply<A, B>(
+        _ f: Kind<ForArray, (A) -> B>,
+        _ a: Kind<ForArray, A>
+        ) -> Kind<ForArray, B>
     {
         var arr = [B]()
         for f_ in f.value {

--- a/Sources/HigherKindSwift/Types/Either.swift
+++ b/Sources/HigherKindSwift/Types/Either.swift
@@ -1,0 +1,165 @@
+// MARK: - Either
+
+public enum Either<L, R>
+{
+    case left(L)
+    case right(R)
+}
+
+extension Either: Equatable where L: Equatable, R: Equatable {}
+
+extension Either: Kind2Convertible
+{
+    public typealias F2 = ForEither
+    public typealias A2 = L
+    public typealias A1 = R
+
+    /// - Note: autogeneratable
+    public init(kind2: Kind2<F2, A2, A1>)
+    {
+        self = kind2._value as! Either<A2, A1>
+    }
+
+    /// - Note: autogeneratable
+    public var kind2: Kind2<F2, A2, A1>
+    {
+        return Kind2(self)
+    }
+}
+
+/// - Note: autogeneratable
+extension Either: PseudoBifunctor
+{
+    public func first<B2>(_ f: @escaping (A2) -> B2) -> Either<B2, A1>
+    {
+        return F2.first(f)(self.kind2).value
+    }
+
+    public func second<B1>(_ f: @escaping (A1) -> B1) -> Either<A2, B1>
+    {
+        return F2.second(f)(self.kind2).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Either: PseudoFunctor
+{
+    public func fmap<B>(_ f: @escaping (A1) -> B) -> Either<A2, B>
+    {
+        return Kind<ForEither, A2>.fmap(f)(self.kind).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Either: PseudoApplicative
+{
+    public static func pure(_ value: A1) -> Either<A2, A1>
+    {
+        return Kind<ForEither, A2>.pure(value).value
+    }
+
+    public static func apply<B>(_ f: Either<A2, (A1) -> B>, _ a: Either<A2, A1>) -> Either<A2, B>
+    {
+        return Kind<ForEither, A2>.apply(f.kind, a.kind).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Either: PseudoMonad
+{
+    public func bind<B>(_ f: @escaping (A1) -> Either<A2, B>) -> Either<A2, B>
+    {
+        return Kind<ForEither, A2>.bind({ f($0).kind })(self.kind).value
+    }
+}
+
+// MARK: - ForEither
+
+/// - Note: autogeneratable
+public enum ForEither {}
+
+/// - Note: autogeneratable
+extension Kind2 where F2 == ForEither
+{
+    public var value: Either<A2, A1>
+    {
+        return Either(kind2: self)
+    }
+}
+
+/// - Note: autogeneratable
+extension Kind where F1: KindConvertible, F1.F1 == ForEither
+{
+    public var value: Either<F1.A1, A1>
+    {
+        return self._value as! Either<F1.A1, A1>
+    }
+}
+
+// MARK: ForBifunctor
+
+extension ForEither: ForBifunctor
+{
+    public static func bimap<A2, A1, B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<ForEither, A2, A1>) -> Kind2<ForEither, B2, B1>
+    {
+        return { kind2 in
+            switch kind2.value {
+            case let .left(l):
+                return Either<B2, B1>.left(f1(l)).kind2
+            case let .right(r):
+                return Either<B2, B1>.right(f2(r)).kind2
+            }
+
+        }
+    }
+}
+
+// MARK: ForApplicative2
+
+extension ForEither: ForApplicative2
+{
+    public static func pure<A2, A>(_ value: A) -> Kind<Kind<ForEither, A2>, A>
+    {
+        return Either<A2, A>.right(value).kind
+    }
+
+    public static func apply<A2, A, B>(
+        _ f: Kind<Kind<ForEither, A2>, (A) -> B>,
+        _ a: Kind<Kind<ForEither, A2>, A>
+        ) -> Kind<Kind<ForEither, A2>, B>
+    {
+        switch f.value {
+        case let .left(l):
+            return Either<A2, B>.left(l).kind
+        case let .right(r):
+            switch a.value {
+            case let .left(l2):
+                return Either<A2, B>.left(l2).kind
+            case let .right(r2):
+                return Either<A2, B>.right(r(r2)).kind
+            }
+        }
+    }
+}
+
+// MARK: ForMonad2
+
+extension ForEither: ForMonad2
+{
+    public static func bind<A2, A, B>(
+        _ f: @escaping (A) -> Kind<Kind<ForEither, A2>, B>
+        ) -> (Kind<Kind<ForEither, A2>, A>) -> Kind<Kind<ForEither, A2>, B>
+    {
+        return { kind in
+            switch kind.value {
+            case let .left(l):
+                return Either<A2, B>.left(l).kind
+            case let .right(r):
+                return f(r)
+            }
+        }
+    }
+}

--- a/Sources/HigherKindSwift/Types/List.swift
+++ b/Sources/HigherKindSwift/Types/List.swift
@@ -59,12 +59,12 @@ extension List: PseudoFunctor
 /// - Note: autogeneratable
 extension List: PseudoApplicative
 {
-    public static func pure<A>(_ value: A) -> List<A>
+    public static func pure(_ value: A1) -> List<A1>
     {
         return ForList.pure(value).value
     }
 
-    public static func apply<A, B>(_ f: List<(A) -> B>, _ a: List<A>) -> List<B>
+    public static func apply<B>(_ f: List<(A1) -> B>, _ a: List<A1>) -> List<B>
     {
         return ForList.apply(f.kind, a.kind).value
     }
@@ -85,7 +85,7 @@ extension List: PseudoMonad
 public enum ForList {}
 
 /// - Note: autogeneratable
-extension Kind where F == ForList
+extension Kind where F1 == ForList
 {
     public var value: List<A1>
     {
@@ -115,11 +115,14 @@ extension ForList: ForApplicative
         return List<A>.cons(value, .nil).kind
     }
 
-    public static func apply<A, B>(_ f: Kind<ForList, (A) -> B>, _ a: Kind<ForList, A>) -> Kind<ForList, B>
+    public static func apply<A, B>(
+        _ f: Kind<ForList, (A) -> B>,
+        _ a: Kind<ForList, A>
+        ) -> Kind<ForList, B>
     {
         switch (f.value, a.value) {
         case let (.cons(f, tail1), .cons(a, tail2)):
-            return List<B>.cons(f(a), apply(tail1.kind, tail2.kind).value).kind
+            return List<B>.cons(f(a), self.apply(tail1.kind, tail2.kind).value).kind
         default:
             return List<B>.nil.kind
         }
@@ -128,7 +131,9 @@ extension ForList: ForApplicative
 
 extension ForList: ForMonad
 {
-    public static func bind<A, B>(_ f: @escaping (A) -> Kind<ForList, B>) -> (Kind<ForList, A>) -> Kind<ForList, B>
+    public static func bind<A, B>(
+        _ f: @escaping (A) -> Kind<ForList, B>
+        ) -> (Kind<ForList, A>) -> Kind<ForList, B>
     {
         return { kind in
             switch kind.value {

--- a/Sources/HigherKindSwift/Types/Optional.swift
+++ b/Sources/HigherKindSwift/Types/Optional.swift
@@ -31,12 +31,12 @@ extension Optional: PseudoFunctor
 /// - Note: autogeneratable
 extension Optional: PseudoApplicative
 {
-    public static func pure<A>(_ value: A) -> Optional<A>
+    public static func pure(_ value: A1) -> Optional<A1>
     {
         return ForOptional.pure(value).value
     }
 
-    public static func apply<A, B>(_ f: Optional<(A) -> B>, _ a: Optional<A>) -> Optional<B>
+    public static func apply<B>(_ f: Optional<(A1) -> B>, _ a: Optional<A1>) -> Optional<B>
     {
         return ForOptional.apply(f.kind, a.kind).value
     }
@@ -57,7 +57,7 @@ extension Optional: PseudoMonad
 public enum ForOptional {}
 
 /// - Note: autogeneratable
-extension Kind where F == ForOptional
+extension Kind where F1 == ForOptional
 {
     public var value: Optional<A1>
     {
@@ -80,7 +80,10 @@ extension ForOptional: ForApplicative
         return Optional<A>(value).kind
     }
 
-    public static func apply<A, B>(_ f: Kind<ForOptional, (A) -> B>, _ a: Kind<ForOptional, A>) -> Kind<ForOptional, B>
+    public static func apply<A, B>(
+        _ f: Kind<ForOptional, (A) -> B>,
+        _ a: Kind<ForOptional, A>
+        ) -> Kind<ForOptional, B>
     {
         if let f = f.value, let a = a.value {
             return Optional(f(a)).kind
@@ -93,7 +96,9 @@ extension ForOptional: ForApplicative
 
 extension ForOptional: ForMonad
 {
-    public static func bind<A, B>(_ f: @escaping (A) -> Kind<ForOptional, B>) -> (Kind<ForOptional, A>) -> Kind<ForOptional, B>
+    public static func bind<A, B>(
+        _ f: @escaping (A) -> Kind<ForOptional, B>
+        ) -> (Kind<ForOptional, A>) -> Kind<ForOptional, B>
     {
         return { $0.value.flatMap { f($0).value }.kind }
     }

--- a/Sources/HigherKindSwift/Types/Reader.swift
+++ b/Sources/HigherKindSwift/Types/Reader.swift
@@ -10,41 +10,74 @@ public struct Reader<X, Y>
     }
 }
 
+/// - Note: autogeneratable
 extension Reader: Kind2Convertible
 {
-    public typealias F = ForReader
-    public typealias A1 = X
-    public typealias A2 = Y
+    public typealias F2 = ForReader
+    public typealias A2 = X
+    public typealias A1 = Y
 
-    /// - Note: autogeneratable
-    public init(kind2: Kind2<F, A1, A2>)
+    public init(kind2: Kind2<F2, A2, A1>)
     {
-        self = kind2._value as! Reader<A1, A2>
+        self = kind2._value as! Reader<A2, A1>
     }
 
-    /// - Note: autogeneratable
-    public var kind2: Kind2<F, A1, A2>
+    public var kind2: Kind2<F2, A2, A1>
     {
         return Kind2(self as Any)
     }
 }
 
+// MARK: Pseudo protocol conformances
+
 /// - Note: autogeneratable
 extension Reader: PseudoProfunctor
 {
-    public func dimap<B1, B2>(_ f1: @escaping (B1) -> A1, _ f2: @escaping (A2) -> B2) -> Reader<B1, B2>
+    public func dimap<B2, B1>(_ f1: @escaping (B2) -> A2, _ f2: @escaping (A1) -> B1) -> Reader<B2, B1>
     {
         return self.kind2.dimap(f1, f2).value
     }
 
-    public func lmap<B1>(_ f: @escaping (B1) -> A1) -> Reader<B1, A2>
+    public func lmap<B2>(_ f: @escaping (B2) -> A2) -> Reader<B2, A1>
     {
         return self.kind2.lmap(f).value
     }
 
-    public func rmap<B2>(_ f: @escaping (A2) -> B2) -> Reader<A1, B2>
+    public func rmap<B1>(_ f: @escaping (A1) -> B1) -> Reader<A2, B1>
     {
         return self.kind2.rmap(f).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Reader: PseudoFunctor
+{
+    public func fmap<B>(_ f: @escaping (A1) -> B) -> Reader<A2, B>
+    {
+        return Kind<ForReader, A2>.fmap(f)(self.kind).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Reader: PseudoApplicative
+{
+    public static func pure(_ value: A1) -> Reader<A2, A1>
+    {
+        return Kind<ForReader, A2>.pure(value).value
+    }
+
+    public static func apply<B>(_ f: Reader<A2, (A1) -> B>, _ a: Reader<A2, A1>) -> Reader<A2, B>
+    {
+        return Kind<ForReader, A2>.apply(f.kind, a.kind).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Reader: PseudoMonad
+{
+    public func bind<B>(_ f: @escaping (A1) -> Reader<A2, B>) -> Reader<A2, B>
+    {
+        return Kind<ForReader, A2>.bind({ f($0).kind })(self.kind).value
     }
 }
 
@@ -54,23 +87,90 @@ extension Reader: PseudoProfunctor
 public enum ForReader {}
 
 /// - Note: autogeneratable
-extension Kind2 where F == ForReader
+extension Kind2 where F2 == ForReader
 {
-    public var value: Reader<A1, A2>
+    public var value: Reader<A2, A1>
     {
         return Reader(kind2: self)
     }
 }
 
+/// - Note: autogeneratable
+extension Kind where F1: KindConvertible, F1.F1 == ForReader
+{
+    public var value: Reader<F1.A1, A1>
+    {
+        return self._value as! Reader<F1.A1, A1>
+    }
+}
+
+// MARK: ForProfunctor
+
 extension ForReader: ForProfunctor
 {
-    public static func lmap<A1, A2, B1>(_ f: @escaping (B1) -> A1) -> (Kind2<ForReader, A1, A2>) -> Kind2<ForReader, B1, A2>
+    public static func dimap<A2, A1, B2, B1>(
+        _ f1: @escaping (B2) -> A2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<ForReader, A2, A1>) -> Kind2<ForReader, B2, B1>
+    {
+        return { kind2 in Reader { f2(kind2.value.run(f1($0))) }.kind2 }
+    }
+
+    public static func lmap<A1, A2, B1>(
+        _ f: @escaping (B1) -> A1
+        ) -> (Kind2<ForReader, A1, A2>) -> Kind2<ForReader, B1, A2>
     {
         return { kind2 in Reader { kind2.value.run(f($0)) }.kind2 }
     }
 
-    public static func rmap<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<ForReader, A1, A2>) -> Kind2<ForReader, A1, B2>
+    public static func rmap<A1, A2, B2>(
+        _ f: @escaping (A2) -> B2
+        ) -> (Kind2<ForReader, A1, A2>) -> Kind2<ForReader, A1, B2>
     {
         return { kind2 in Reader { f(kind2.value.run($0)) }.kind2 }
+    }
+}
+
+// MARK: ForFunctor2
+
+extension ForReader: ForFunctor2
+{
+    public static func fmap<A2, A, B>(
+        _ f: @escaping (A) -> B
+        ) -> (Kind<Kind<ForReader, A2>, A>) -> Kind<Kind<ForReader, A2>, B>
+    {
+        return { $0.value.kind2.rmap(f).kind }
+    }
+}
+
+// MARK: ForApplicative2
+
+extension ForReader: ForApplicative2
+{
+    public static func pure<A2, A>(_ value: A) -> Kind<Kind<ForReader, A2>, A>
+    {
+        return Reader<A2, A> { _ in value }.kind
+    }
+
+    public static func apply<A2, A, B>(
+        _ f: Kind<Kind<ForReader, A2>, (A) -> B>,
+        _ a: Kind<Kind<ForReader, A2>, A>
+        ) -> Kind<Kind<ForReader, A2>, B>
+    {
+        return Reader<A2, B> { f.value.run($0)(a.value.run($0)) }.kind
+    }
+}
+
+// MARK: ForMonad2
+
+extension ForReader: ForMonad2
+{
+    public static func bind<A2, A, B>(
+        _ f: @escaping (A) -> Kind<Kind<ForReader, A2>, B>
+        ) -> (Kind<Kind<ForReader, A2>, A>) -> Kind<Kind<ForReader, A2>, B>
+    {
+        return { kind in
+            return Reader<A2, B> { return f(kind.value.run($0)).value.run($0) }.kind
+        }
     }
 }

--- a/Sources/HigherKindSwift/Types/Tree.swift
+++ b/Sources/HigherKindSwift/Types/Tree.swift
@@ -69,7 +69,7 @@ extension Tree: PseudoFunctor
 public enum ForTree {}
 
 /// - Note: autogeneratable
-extension Kind where F == ForTree
+extension Kind where F1 == ForTree
 {
     public var value: Tree<A1>
     {

--- a/Sources/HigherKindSwift/Types/Tuple2.swift
+++ b/Sources/HigherKindSwift/Types/Tuple2.swift
@@ -16,18 +16,18 @@ extension Tuple2: Equatable where X: Equatable, Y: Equatable {}
 
 extension Tuple2: Kind2Convertible
 {
-    public typealias F = ForTuple2
-    public typealias A1 = X
-    public typealias A2 = Y
+    public typealias F2 = ForTuple2
+    public typealias A2 = X
+    public typealias A1 = Y
 
     /// - Note: autogeneratable
-    public init(kind2: Kind2<F, A1, A2>)
+    public init(kind2: Kind2<F2, A2, A1>)
     {
-        self = kind2._value as! Tuple2<A1, A2>
+        self = kind2._value as! Tuple2<A2, A1>
     }
 
     /// - Note: autogeneratable
-    public var kind2: Kind2<F, A1, A2>
+    public var kind2: Kind2<F2, A2, A1>
     {
         return Kind2(self)
     }
@@ -36,14 +36,23 @@ extension Tuple2: Kind2Convertible
 /// - Note: autogeneratable
 extension Tuple2: PseudoBifunctor
 {
-    public func first<B1>(_ f: @escaping (A1) -> B1) -> Tuple2<B1, A2>
+    public func first<B2>(_ f: @escaping (A2) -> B2) -> Tuple2<B2, A1>
     {
-        return F.first(f)(self.kind2).value
+        return F2.first(f)(self.kind2).value
     }
 
-    public func second<B2>(_ f: @escaping (A2) -> B2) -> Tuple2<A1, B2>
+    public func second<B1>(_ f: @escaping (A1) -> B1) -> Tuple2<A2, B1>
     {
-        return F.second(f)(self.kind2).value
+        return F2.second(f)(self.kind2).value
+    }
+}
+
+/// - Note: autogeneratable
+extension Tuple2: PseudoFunctor
+{
+    public func fmap<B>(_ f: @escaping (A1) -> B) -> Tuple2<X, B>
+    {
+        return Kind<ForTuple2, X>.fmap(f)(self.kind).value
     }
 }
 
@@ -53,29 +62,38 @@ extension Tuple2: PseudoBifunctor
 public enum ForTuple2 {}
 
 /// - Note: autogeneratable
-extension Kind2 where F == ForTuple2
+extension Kind2 where F2 == ForTuple2
 {
-    public var value: Tuple2<A1, A2>
+    public var value: Tuple2<A2, A1>
     {
         return Tuple2(kind2: self)
     }
 }
 
+/// - Note: autogeneratable
+extension Kind where F1: KindConvertible, F1.F1 == ForTuple2
+{
+    public var value: Tuple2<F1.A1, A1>
+    {
+        return self._value as! Tuple2<F1.A1, A1>
+    }
+}
+
+// MARK: ForBifunctor
+
 extension ForTuple2: ForBifunctor
 {
-    public static func first<A1, A2, B1>(_ f: @escaping (A1) -> B1) -> (Kind2<ForTuple2, A1, A2>) -> Kind2<ForTuple2, B1, A2>
+    public static func bimap<A2, A1, B2, B1>(
+        _ f1: @escaping (A2) -> B2,
+        _ f2: @escaping (A1) -> B1
+        ) -> (Kind2<ForTuple2, A2, A1>) -> Kind2<ForTuple2, B2, B1>
     {
         return { kind2 in
             let value = kind2.value
-            return Tuple2(f(value.x), value.y).kind2
-        }
-    }
-
-    public static func second<A1, A2, B2>(_ f: @escaping (A2) -> B2) -> (Kind2<ForTuple2, A1, A2>) -> Kind2<ForTuple2, A1, B2>
-    {
-        return { kind2 in
-            let value = kind2.value
-            return Tuple2(value.x, f(value.y)).kind2
+            return Tuple2(f1(value.x), f2(value.y)).kind2
         }
     }
 }
+
+// TODO: `instance Monoid a => Applicative ((,) a)`
+// TODO: `instance Monoid a => Monad ((,) a)`

--- a/Tests/HigherKindSwiftTests/BifunctorTests.swift
+++ b/Tests/HigherKindSwiftTests/BifunctorTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+import HigherKindSwift
+
+final class BifunctorTests: XCTestCase
+{
+    func testTuple2()
+    {
+        describe("Without Kind") {
+
+            it("Tuple2.first") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.first { $0 + 1 }
+                XCTAssertEqual(result, Tuple2(2, "ok"))
+            }
+
+            it("Tuple2.second") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.second { $0.uppercased() + "!" }
+                XCTAssertEqual(result, Tuple2(1, "OK!"))
+            }
+
+        }
+
+        describe("With Kind") {
+
+            it("Tuple2.kind2.first") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.kind2.first { $0 + 1 }.value
+                XCTAssertEqual(result, Tuple2(2, "ok"))
+            }
+
+            it("Tuple2.kind2.second") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.kind2.second { $0.uppercased() + "!" }.value
+                XCTAssertEqual(result, Tuple2(1, "OK!"))
+            }
+
+        }
+    }
+
+    func testEither()
+    {
+        describe("Without Kind") {
+
+            it("Either.first") {
+                do {
+                    let either = Either<String, Int>.left("Bad")
+                    let result = either.first { $0 + "!" }
+                    XCTAssertEqual(result, Either<String, Int>.left("Bad!"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1)
+                    let result = either.first { $0 + "!" }
+                    XCTAssertEqual(result, Either<String, Int>.right(1))
+                }
+            }
+
+            it("Either.second") {
+                do {
+                    let either = Either<String, Int>.left("Bad")
+                    let result = either.second { $0 + 100 }
+                    XCTAssertEqual(result, Either<String, Int>.left("Bad"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1)
+                    let result = either.second { $0 + 100 }
+                    XCTAssertEqual(result, Either<String, Int>.right(101))
+                }
+            }
+
+            it("Either.fmap") {
+                do {
+                    let either = Either<String, Int>.left("Bad")
+                    let result = either.fmap { $0 + 100 }
+                    XCTAssertEqual(result, Either<String, Int>.left("Bad"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1)
+                    let result = either.fmap { $0 + 100 }
+                    XCTAssertEqual(result, Either<String, Int>.right(101))
+                }
+            }
+
+            it("Either.bind") {
+                do {
+                    let either = Either<String, Int>.left("Bad")
+                    let result = either.bind { Either<String, Bool>.right($0 > 100 ? true : false) }
+                    XCTAssertEqual(result, Either<String, Bool>.left("Bad"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1)
+                    let result = either.bind { Either<String, Bool>.right($0 > 100 ? true : false) }
+                    XCTAssertEqual(result, Either<String, Bool>.right(false))
+                }
+            }
+
+        }
+
+        describe("With Kind") {
+
+            it("Either.kind2.first") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.kind2.first { $0 + 1 }.value
+                XCTAssertEqual(result, Tuple2(2, "ok"))
+            }
+
+            it("Either.kind2.second") {
+                let tuple = Tuple2(1, "ok")
+                let result = tuple.kind2.second { $0.uppercased() + "!" }.value
+                XCTAssertEqual(result, Tuple2(1, "OK!"))
+            }
+
+            it("Either.kind.fmap") {
+                do {
+                    let either = Either<String, Int>.left("Bad").kind
+                    let result = either.fmap { $0 + 100 }.value
+                    XCTAssertEqual(result, Either<String, Int>.left("Bad"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1).kind
+                    let result = either.fmap { $0 + 100 }.value
+                    XCTAssertEqual(result, Either<String, Int>.right(101))
+                }
+            }
+
+            it("Either.kind.bind") {
+                do {
+                    let either = Either<String, Int>.left("Bad").kind
+                    let result = either.bind { Either<String, Bool>.right($0 > 100 ? true : false).kind }.value
+                    XCTAssertEqual(result, Either<String, Bool>.left("Bad"))
+                }
+
+                do {
+                    let either = Either<String, Int>.right(1).kind
+                    let result = either.bind { Either<String, Bool>.right($0 > 100 ? true : false).kind }.value
+                    XCTAssertEqual(result, Either<String, Bool>.right(false))
+                }
+            }
+        }
+    }
+
+    static let allTests = [
+        ("testTuple2", testTuple2),
+        ("testEither", testEither),
+    ]
+}

--- a/Tests/HigherKindSwiftTests/Fixtures/TestHelpers.swift
+++ b/Tests/HigherKindSwiftTests/Fixtures/TestHelpers.swift
@@ -1,6 +1,16 @@
 import XCTest
 import _SwiftXCTestOverlayShims
 
+public func describe(_ name: String, _ task: () -> ())
+{
+    it(name, task)
+}
+
+public func context(_ name: String, _ task: () -> ())
+{
+    it(name, task)
+}
+
 public func it(_ name: String, _ task: () -> ())
 {
     // https://github.com/apple/swift/blob/50fb3b8496f9501c95326a1f9e33638e56797fb0/stdlib/public/SDK/XCTest/XCTest.swift#L26

--- a/Tests/HigherKindSwiftTests/MonadTests.swift
+++ b/Tests/HigherKindSwiftTests/MonadTests.swift
@@ -1,11 +1,12 @@
 import XCTest
-@testable import HigherKindSwift
+import HigherKindSwift
 
 final class MonadTests: XCTestCase
 {
     func testArray()
     {
-        it("Without Kind") {
+        describe("Without Kind") {
+
             it("Array.fmap") {
                 let result = [1, 2, 3]
                     .fmap { "\($0)!" }
@@ -17,9 +18,11 @@ final class MonadTests: XCTestCase
                     .bind { [$0 * 3, $0 * 5 ] }
                 XCTAssertEqual(result, [3, 5, 6, 10, 9, 15])
             }
+
         }
 
-        it("With Kind") {
+        describe("With Kind") {
+
             it("Array.kind.fmap") {
                 let result = [1, 2, 3].kind
                     .fmap { "\($0)!" }.value
@@ -31,6 +34,7 @@ final class MonadTests: XCTestCase
                     .bind { [$0 * 3, $0 * 5 ].kind }.value
                 XCTAssertEqual(result, [3, 5, 6, 10, 9, 15])
             }
+
         }
     }
 
@@ -38,7 +42,8 @@ final class MonadTests: XCTestCase
     {
         let list = List<Int>.cons(1, .cons(2, .cons(3, .nil)))
 
-        it("Without Kind") {
+        describe("Without Kind") {
+
             it("List.fmap") {
                 let result = list
                     .fmap { "\($0)!" }
@@ -53,9 +58,11 @@ final class MonadTests: XCTestCase
                     List.cons(3, .cons(5, .cons(6, .cons(10, .cons(9, .cons(15, .nil))))))
                 )
             }
+
         }
 
-        it("With Kind") {
+        describe("With Kind") {
+
             it("List.kind.fmap") {
                 let result = list.kind
                     .fmap { "\($0)!" }.value
@@ -70,6 +77,7 @@ final class MonadTests: XCTestCase
                     List.cons(3, .cons(5, .cons(6, .cons(10, .cons(9, .cons(15, .nil))))))
                 )
             }
+
         }
     }
 
@@ -89,86 +97,24 @@ final class MonadTests: XCTestCase
                 .node(.leaf, 4, .leaf)
             )
 
-        it("Without Kind") {
+        describe("Without Kind") {
+
             it("Tree.fmap") {
                 let result = tree
                     .fmap { $0 + 1 }
                 XCTAssertEqual(result, tree2)
             }
+
         }
 
-        it("With Kind") {
+        describe("With Kind") {
+
             it("Tree.kind.fmap") {
                 let result = tree.kind
                     .fmap { $0 + 1 }.value
                 XCTAssertEqual(result, tree2)
             }
-        }
-    }
 
-    func testReader()
-    {
-        it("Without Kind") {
-            it("Reader.lmap") {
-                let reader = Reader<Int, String> { "\($0)abc" }
-                let reader2: Reader<Bool, String> = reader.lmap { $0 ? 1 : 0 }
-                let result = reader2.run(true)
-                XCTAssertEqual(result, "1abc")
-            }
-
-            it("Reader.rmap") {
-                let reader = Reader<Int, String> { "\($0)abc" }
-                let reader2 = reader.rmap { $0.uppercased() }
-                let result = reader2.run(100)
-                XCTAssertEqual(result, "100ABC")
-            }
-        }
-
-        it("With Kind") {
-            it("Reader.kind.lmap") {
-                let reader = Reader<Int, String> { "\($0)abc" }
-                let reader2: Reader<Bool, String> = reader.kind2.lmap { $0 ? 1 : 0 }.value
-                let result = reader2.run(true)
-                XCTAssertEqual(result, "1abc")
-            }
-
-            it("Reader.kind.rmap") {
-                let reader = Reader<Int, String> { "\($0)abc" }
-                let reader2 = reader.kind2.rmap { $0.uppercased() }.value
-                let result = reader2.run(100)
-                XCTAssertEqual(result, "100ABC")
-            }
-        }
-    }
-
-    func testTuple2()
-    {
-        it("Without Kind") {
-            it("Tuple2.first") {
-                let tuple = Tuple2(1, "ok")
-                let result = tuple.first { $0 + 1 }
-                XCTAssertEqual(result, Tuple2(2, "ok"))
-            }
-
-            it("Tuple2.second") {
-                let tuple = Tuple2(1, "ok")
-                let result = tuple.second { $0.uppercased() + "!" }
-                XCTAssertEqual(result, Tuple2(1, "OK!"))
-            }
-        }
-
-        it("With Kind") {
-            it("Tuple2.kind2.first") {
-                let tuple = Tuple2(1, "ok")
-                let result = tuple.kind2.first { $0 + 1 }.value
-                XCTAssertEqual(result, Tuple2(2, "ok"))
-            }
-
-            it("Tuple2.kind2.second") {
-                let tuple = Tuple2(1, "ok")
-                let result = tuple.kind2.second { $0.uppercased() + "!" }.value
-                XCTAssertEqual(result, Tuple2(1, "OK!"))
-            }
         }
     }
 
@@ -176,7 +122,5 @@ final class MonadTests: XCTestCase
         ("testArray", testArray),
         ("testList", testList),
         ("testTree", testTree),
-        ("testReader", testReader),
-        ("testTuple2", testTuple2),
     ]
 }

--- a/Tests/HigherKindSwiftTests/NaturalTransformationTests.swift
+++ b/Tests/HigherKindSwiftTests/NaturalTransformationTests.swift
@@ -1,14 +1,14 @@
 import Prelude
 import SwiftCheck
-
 import XCTest
-@testable import HigherKindSwift
+import HigherKindSwift
 
 final class NaturalTransformationTests: XCTestCase
 {
     func testNaturalTransformation()
     {
-        it("Using protocol") {
+        describe("Using protocol") {
+
             it(".some(1) -> [1]") {
                 let result = Optional(1).kind
                     .naturalTransform(OptionalToArray.self).value
@@ -32,9 +32,11 @@ final class NaturalTransformationTests: XCTestCase
                     .naturalTransform(ListToArray.self).value
                 XCTAssertEqual(result, [1, 2, 3])
             }
+
         }
 
-        it("Custom functions") {
+        describe("Custom functions") {
+
             it("Inline closure") {
                 let result = [1, 2, 3].kind
                     .naturalTransform { $0.value.first.kind }.value
@@ -51,9 +53,10 @@ final class NaturalTransformationTests: XCTestCase
                     .naturalTransform(first).value
                 XCTAssertEqual(result, .some(1))
             }
+
         }
 
-        it("Naturality condition") {
+        describe("Naturality condition") {
 
             /// Plain morphism: String -> Int
             func f(_ str: String) -> Int

--- a/Tests/HigherKindSwiftTests/ProfunctorTests.swift
+++ b/Tests/HigherKindSwiftTests/ProfunctorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import HigherKindSwift
+
+final class ProfunctorTests: XCTestCase
+{
+    func testReader()
+    {
+        describe("Without Kind") {
+
+            context("Profunctor") {
+
+                it("Reader.dimap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2: Reader<Bool, String> = reader.dimap({ $0 ? 1 : 0 }, { $0.uppercased() })
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, "1ABC")
+                }
+
+                it("Reader.lmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2: Reader<Bool, String> = reader.lmap { $0 ? 1 : 0 }
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, "1abc")
+                }
+
+                it("Reader.rmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2 = reader.rmap { $0.uppercased() }
+                    let result = reader2.run(100)
+                    XCTAssertEqual(result, "100ABC")
+                }
+
+            }
+
+            context("Functor") {
+
+                it("Reader.fmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2 = reader.fmap { $0.uppercased() }
+                    let result = reader2.run(100)
+                    XCTAssertEqual(result, "100ABC")
+                }
+
+                it("Reader.pure") {
+                    let reader = Reader<Int, String>.pure("OK")
+                    let result = reader.run(100)
+                    XCTAssertEqual(result, "OK")
+                }
+
+                it("Reader.apply") {
+                    let reader = Reader<Bool, (String) -> Int>.pure { $0.count }
+                    let reader2 = Reader<Bool, String>.pure("Hello")
+                    let result = Reader.apply(reader, reader2).run(true)
+                    XCTAssertEqual(result, 5)
+                }
+
+                it("Reader.bind") {
+                    let reader = Reader<Bool, String>.pure("Hello")
+                    let reader2 = reader.bind { Reader<Bool, Int>.pure($0.count) }
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, 5)
+                }
+
+            }
+        }
+
+        describe("With Kind") {
+
+            context("Profunctor (kind2)") {
+
+                it("Reader.kind2.dimap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }.kind2
+                    let reader2 = ForReader
+                        .dimap({ $0 ? 1 : 0 }, { $0.uppercased() })(reader)
+                        .value
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, "1ABC")
+                }
+
+                it("Reader.kind2.lmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2: Reader<Bool, String> = reader.kind2.lmap { $0 ? 1 : 0 }.value
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, "1abc")
+                }
+
+                it("Reader.kind2.rmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2 = reader.kind2.rmap { $0.uppercased() }.value
+                    let result = reader2.run(100)
+                    XCTAssertEqual(result, "100ABC")
+                }
+
+            }
+
+            context("Functor (kind)") {
+
+                it("Reader.kind.fmap") {
+                    let reader = Reader<Int, String> { "\($0)abc" }
+                    let reader2 = reader.kind.fmap { $0.uppercased() }.value
+                    let result = reader2.run(100)
+                    XCTAssertEqual(result, "100ABC")
+                }
+
+                it("Reader.kind.pure") {
+                    let reader = Kind<Kind<ForReader, Int>, String>.pure("OK")
+                    let result = reader.value.run(100)
+                    XCTAssertEqual(result, "OK")
+                }
+
+                it("Reader.kind.apply") {
+                    let reader = Kind<Kind<ForReader, Bool>, (String) -> Int>.pure { $0.count }
+                    let reader2 = Kind<Kind<ForReader, Bool>, String>.pure("Hello").kind
+                    let result = Kind<ForReader, Bool>.apply(reader, reader2).value.run(true)
+                    XCTAssertEqual(result, 5)
+                }
+
+                it("Reader.kind.bind") {
+                    let reader = Kind<Kind<ForReader, Bool>, String>.pure("Hello").kind
+                    let reader2 = reader.kind.bind { Kind<Kind<ForReader, Bool>, Int>.pure($0.count) }.value
+                    let result = reader2.run(true)
+                    XCTAssertEqual(result, 5)
+                }
+
+            }
+
+        }
+    }
+
+    static let allTests = [
+        ("testReader", testReader),
+    ]
+}


### PR DESCRIPTION
This PR will support **nested `Kind` handling** such as `Bifunctor` that can also work as `Functor`.

For example, `Either` can be described as:

1. `Kind2<ForEither, L, R>` where `Bifunctor` lives
2. `Kind<Kind<ForEither, L>, R>` where `Functor` lives

and this PR will support 2.

### Example

```swift
// map first (Bifunctor)
do {
    let either = Either<String, Int>.left("Bad")
    let result = either.first { $0 + "!" }
    XCTAssertEqual(result, Either<String, Int>.left("Bad!"))
}

// bind (Monad)
do {
    let either = Either<String, Int>.right(1)
    let result = either.bind { Either<String, Bool>.right($0 > 100 ? true : false) }
    XCTAssertEqual(result, Either<String, Bool>.right(false))
}
```

Please see [BifunctorTests.swift](https://github.com/inamiy/HigherKindSwift/blob/430cd2a142dbcdf5358d4466b214d34b42e7f294/Tests/HigherKindSwiftTests/BifunctorTests.swift) for more detail.

## How it works

Please see [`ForFunctor2`, `ForApplicative2`, `ForMonad2`](https://github.com/inamiy/HigherKindSwift/blob/430cd2a142dbcdf5358d4466b214d34b42e7f294/Sources/HigherKindSwift/Typeclasses/ForFunctor2.swift).
(This may be a premature idea and not an elegant solution. If you know a better idea, ping me 😄)

## Caveat

Due to Swift 4.2 compiler bug (?) in debug build mode, only `swift build -c release` is supported. 